### PR TITLE
feat(README): Use original capitalization of discord4py

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     ·
     <a href="https://devsky.one">Website</a>
     ·
-    <a href="https://github.com/mccoderpy/discord.py-message-components">Discord4Py (Libary)</a>
+    <a href="https://discord4py.dev/tree/developer" alt="discord4py is the Discord API-Wrapper the Drops-Bot uses">discord4py (library)</a>
   </p>
 </div>
 


### PR DESCRIPTION
- Use original capitalization of discord4py
- Use discord4py.dev instead of the direct GitHub URL

Signed-off-by: Mathieu <80390413+mccoderpy@users.noreply.github.com>